### PR TITLE
Fix workflow image tag for kfserving-predictor

### DIFF
--- a/workflows/mlflow-e2e.yaml
+++ b/workflows/mlflow-e2e.yaml
@@ -42,7 +42,7 @@ steps:
         product: mlflow
         service_resource: s3
   - name: predictor
-    image: ghcr.io/fuseml/kfserving-predictor:0.2.1
+    image: ghcr.io/fuseml/kfserving-predictor:v0.2.1
     inputs:
       - name: model
         value: '{{ steps.trainer.outputs.mlflow-model-url }}'


### PR DESCRIPTION
To be consistent with all other images built and released with
FuseML.