### PR TITLE
keras: Add python as dependency

### DIFF
--- a/codesets/mlflow/keras/conda.yaml
+++ b/codesets/mlflow/keras/conda.yaml
@@ -3,10 +3,11 @@ channels:
   - nvidia
   - conda-forge
 dependencies:
+  - python=3.9
   - cudatoolkit>=11.4
   - cuda-cupti>=11.4
   - cudnn>=8.2
   - pip
   - pip:
-    - mlflow
-    - tensorflow
+      - mlflow
+      - tensorflow


### PR DESCRIPTION
Add python 3.9 as dependency to the keras codeset as tensorflow
does not support python > 3.9.