### PR TITLE
Reference `latest` image tags in workflows

### DIFF
--- a/workflows/mlflow-e2e.yaml
+++ b/workflows/mlflow-e2e.yaml
@@ -17,7 +17,7 @@ outputs:
     type: string
 steps:
   - name: builder
-    image: ghcr.io/fuseml/mlflow-builder:dev
+    image: ghcr.io/fuseml/mlflow-builder:latest
     inputs:
       - name: mlflow-codeset
         codeset:
@@ -42,7 +42,7 @@ steps:
         product: mlflow
         service_resource: s3
   - name: predictor
-    image: ghcr.io/fuseml/kfserving-predictor:dev
+    image: ghcr.io/fuseml/kfserving-predictor:latest
     inputs:
       - name: model
         value: '{{ steps.trainer.outputs.mlflow-model-url }}'

--- a/workflows/mlflow-ovms-e2e.yaml
+++ b/workflows/mlflow-ovms-e2e.yaml
@@ -20,7 +20,7 @@ outputs:
     type: string
 steps:
   - name: builder
-    image: ghcr.io/fuseml/mlflow-builder:dev
+    image: ghcr.io/fuseml/mlflow-builder:latest
     inputs:
       - name: mlflow-codeset
         codeset:
@@ -45,7 +45,7 @@ steps:
         product: mlflow
         service_resource: s3
   - name: converter
-    image: ghcr.io/fuseml/ovms-converter:dev
+    image: ghcr.io/fuseml/ovms-converter:latest
     inputs:
       - name: input_model
         value: '{{ steps.trainer.outputs.mlflow-model-url }}'
@@ -65,7 +65,7 @@ steps:
       - name: S3_ENDPOINT
         value: '{{ extensions.mlflow-store.cfg.MLFLOW_S3_ENDPOINT_URL }}'
   - name: predictor
-    image: ghcr.io/fuseml/ovms-predictor:dev
+    image: ghcr.io/fuseml/ovms-predictor:latest
     inputs:
       - name: model
         value: '{{ steps.converter.outputs.ovms-model-url }}'

--- a/workflows/mlflow-seldon-e2e.yaml
+++ b/workflows/mlflow-seldon-e2e.yaml
@@ -17,7 +17,7 @@ outputs:
     type: string
 steps:
   - name: builder
-    image: ghcr.io/fuseml/mlflow-builder:dev
+    image: ghcr.io/fuseml/mlflow-builder:latest
     inputs:
       - name: mlflow-codeset
         codeset:
@@ -42,7 +42,7 @@ steps:
         product: mlflow
         service_resource: s3
   - name: predictor
-    image: ghcr.io/fuseml/seldon-core-predictor:dev
+    image: ghcr.io/fuseml/seldon-core-predictor:latest
     inputs:
       - name: model
         value: '{{ steps.trainer.outputs.mlflow-model-url }}'


### PR DESCRIPTION
Usint the `latest` tag forces Tekton to always refresh the local k8s
image cache, if newer images are available in the remote registry.
This makes it easier to test local development changes in the context
of up-to-date workflow step container images.

Depends on https://github.com/fuseml/extensions/pull/62