### PR TITLE
Fix OVMS e2e workflow

### DIFF
--- a/workflows/mlflow-ovms-e2e.yaml
+++ b/workflows/mlflow-ovms-e2e.yaml
@@ -44,6 +44,9 @@ steps:
       - name: mlflow-store
         product: mlflow
         service_resource: s3
+    env:
+      - name: TF_ENABLE_ONEDNN_OPTS
+        value: 1
   - name: converter
     image: ghcr.io/fuseml/ovms-converter:latest
     inputs:
@@ -55,6 +58,8 @@ steps:
         value: '{{ inputs.model-format }}'
       - name: output_format
         value: 'openvino'
+      - name: batch
+        value: 1 # OpenVINO cannot work with undefined input dimensions
     outputs:
       - name: ovms-model-url
     extensions:


### PR DESCRIPTION
The OVMS converter's batch parameter is no longer set by default
and needs to be set explicitly in the workflow. This change also
enables Intel TensorFlow optimizations by setting the necessary
environment variable in the training workflow step.